### PR TITLE
Nexmo request parameter format change

### DIFF
--- a/src/Service/Message.php
+++ b/src/Service/Message.php
@@ -91,13 +91,13 @@ class Message extends Service
             'to' => $to,
             'type' => $type,
             'text' => $text,
-            'status_report_req' => $statusReportReq,
-            'client_ref' => $clientRef,
-            'network_code' => $networkCode,
+            'status-report-req' => $statusReportReq,
+            'client-ref' => $clientRef,
+            'networ-code' => $networkCode,
             'vcard' => $vcard,
             'vcal' => $vcal,
             'ttl' => $ttl,
-            'message_class' => $messageClass,
+            'message-class' => $messageClass,
             'body' => $body,
             'udh' => $udh
         ]);


### PR DESCRIPTION
Nexmo API has changed the Request parameter formatting from underscore concatenation to hyphen concatenation. Parameter formattin changed accordingly:

When sending SMSs the request parameters are concatenated with underscore:
https://github.com/ConnectCorp/nexmo-client/blob/master/src/Service/Message.php#L96

but Nexmo API says that they should be hyphenated:
https://docs.nexmo.com/api-ref/sms-api/request
